### PR TITLE
with open() automatically calls close()

### DIFF
--- a/highscore_reader.py
+++ b/highscore_reader.py
@@ -1,10 +1,7 @@
 import pickle
 
-file = open("bwsave.dat", "rb")
-test = pickle.load(file)
-file.close()
+with open("bwsave.dat", "rb") as in_file:
+	test = pickle.load(in_file)
 
-test.sort(reverse=True)
-
-for x in test:
-	print x[0], "-", x[1]
+for x in sorted(test, reverse=True):
+	print('{} - {}'.format(*x))


### PR DESCRIPTION
- `file` is a builtin function in Python so `file` should not be used for a variable name.
- `sorted()` returns the sorted list
- `str.format()` helps when you have two or more items to put into a string.
- Star operator (*) to access the items of a thing

Perhaps you should consider json instead of pickle.

``` python
with open('bwsave1.json', 'w') as out_file:
    json.dump(test, out_file, indent=4)
```
